### PR TITLE
Fix for a windows bug with nodemon

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -6,5 +6,5 @@
     "ignore": [
         "src/**/*.test.ts"
     ],
-    "exec": "ts-node src/app.ts"
+    "exec": "npx ts-node src/app.ts"
 }


### PR DESCRIPTION
Fix for a bug mentioned here 
https://github.com/remy/nodemon/issues/1951

Some people will experience this bug on windows.

Using npx as a workaround to run ts-node fixes the path issue. 